### PR TITLE
fix cython on linux

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include lame *.pyx *.px[di]

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ flake8
 pip-tools
 pylint
 twine
+wheel
 
 coveralls
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,5 @@ tqdm==4.23.4              # via twine
 twine==1.11.0
 urllib3==1.23             # via requests
 watchdog==0.8.3           # via pytest-watch
+wheel==0.31.1
 wrapt==1.10.11            # via astroid

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,9 @@
 import setuptools
 from distutils.core import setup
 from distutils.extension import Extension
-from Cython.Build import cythonize
 
 setup(name='streamp3',
-      version='0.1.1',
+      version='0.1.5',
       description="streaming mp3 decoder",
       long_description=open('README.md', 'r').read(),
       long_description_content_type='text/markdown',
@@ -14,10 +13,10 @@ setup(name='streamp3',
       author="Brent M. Spell",
       author_email='brent@pylon.com',
       packages=setuptools.find_packages(),
-      setup_requires=['cython'],
-      ext_modules=cythonize([Extension('lame.hip',
-                                       ['lame/hip.pyx'],
-                                       libraries=['mp3lame'])]),
+      setup_requires=['Cython>=0.28.3'],
+      ext_modules=[Extension('lame.hip',
+                             ['lame/hip.pyx'],
+                             libraries=['mp3lame'])],
       classifiers=("Programming Language :: Python :: 3",
                    "License :: OSI Approved :: Apache Software License",
                    "Operating System :: OS Independent"))


### PR DESCRIPTION
These changes allow the package to be built from a source distribution and take advantage of cython support in setuptools to ensure that cython is installed.