### PR TITLE
install cython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,54 +5,54 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 argh==0.26.2              # via watchdog
-astroid==2.0.4            # via pylint
-atomicwrites==1.2.1       # via pytest
-attrs==18.2.0             # via pytest
-bleach==2.1.4             # via readme-renderer
-certifi==2018.8.24        # via requests
-cffi==1.11.5              # via cmarkgfm
+astroid==2.2.5            # via pylint
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via pytest
+bleach==3.1.0             # via readme-renderer
+certifi==2019.6.16        # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
-cmarkgfm==0.4.2           # via readme-renderer
-colorama==0.3.9           # via pytest-watch
-coverage==4.5.1           # via coveralls, pytest-cov
-coveralls==1.5.1
-cython==0.28.5
+colorama==0.4.1           # via pytest-watch
+coverage==4.5.3           # via coveralls, pytest-cov
+coveralls==1.8.1
+cython==0.29.10
 docopt==0.6.2             # via coveralls, pytest-watch
 docutils==0.14            # via readme-renderer
-flake8==3.5.0
-future==0.16.0            # via readme-renderer
-html5lib==1.0.1           # via bleach
-idna==2.7                 # via requests
-isort==4.3.4              # via pylint
-lazy-object-proxy==1.3.1  # via astroid
+entrypoints==0.3          # via flake8
+flake8==3.7.7
+idna==2.8                 # via requests
+importlib-metadata==0.18  # via pluggy, pytest
+isort==4.3.20             # via pylint
+lazy-object-proxy==1.4.1  # via astroid
 mccabe==0.6.1             # via flake8, pylint
-mock==2.0.0
-more-itertools==4.3.0     # via pytest
+mock==3.0.5
+more-itertools==7.0.0     # via pytest
+packaging==19.0           # via pytest
 pathtools==0.1.2          # via watchdog
-pbr==4.2.0                # via mock
-pip-tools==3.0.0
-pkginfo==1.4.2            # via twine
-pluggy==0.7.1             # via pytest
-py==1.6.0                 # via pytest
-pycodestyle==2.3.1        # via flake8
-pycparser==2.19           # via cffi
-pyflakes==1.6.0           # via flake8
-pygments==2.2.0           # via readme-renderer
-pylint==2.1.1
-pytest-cov==2.6.0
+pip-tools==3.8.0
+pkginfo==1.5.0.1          # via twine
+pluggy==0.12.0            # via pytest
+py==1.8.0                 # via pytest
+pycodestyle==2.5.0        # via flake8
+pyflakes==2.1.1           # via flake8
+pygments==2.4.2           # via readme-renderer
+pylint==2.3.1
+pyparsing==2.4.0          # via packaging
+pytest-cov==2.7.1
 pytest-watch==4.2.0
-pytest==3.8.1
-pyyaml==3.13              # via watchdog
-readme-renderer==22.0     # via twine
-requests-toolbelt==0.8.0  # via twine
-requests==2.19.1          # via coveralls, requests-toolbelt, twine
-six==1.11.0               # via astroid, bleach, html5lib, mock, more-itertools, pip-tools, pytest, readme-renderer
-tqdm==4.26.0              # via twine
-twine==1.12.1
-typed-ast==1.1.0          # via astroid
-urllib3==1.23             # via requests
+pytest==4.6.3
+pyyaml==5.1.1             # via watchdog
+readme-renderer==24.0     # via twine
+requests-toolbelt==0.9.1  # via twine
+requests==2.22.0          # via coveralls, requests-toolbelt, twine
+six==1.12.0               # via astroid, bleach, mock, packaging, pip-tools, pytest, readme-renderer
+tqdm==4.32.2              # via twine
+twine==1.13.0
+typed-ast==1.4.0          # via astroid
+urllib3==1.25.3           # via requests
 watchdog==0.9.0           # via pytest-watch
-webencodings==0.5.1       # via html5lib
-wheel==0.32.0
-wrapt==1.10.11            # via astroid
+wcwidth==0.1.7            # via pytest
+webencodings==0.5.1       # via bleach
+wheel==0.33.4
+wrapt==1.11.2             # via astroid
+zipp==0.5.1               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 
 setup(name='streamp3',
-      version='0.1.5',
+      version='0.1.6',
       description="streaming mp3 decoder",
       long_description=open('README.md', 'r').read(),
       long_description_content_type='text/markdown',
@@ -14,6 +14,7 @@ setup(name='streamp3',
       author_email='brent@pylon.com',
       packages=setuptools.find_packages(),
       setup_requires=['Cython>=0.28.5'],
+      install_requires=['Cython>=0.28.5'],
       ext_modules=[Extension('lame.hip',
                              ['lame/hip.pyx'],
                              libraries=['mp3lame'])],


### PR DESCRIPTION
The repo was declaring the cython dependency via `setup_requires` but not actually installing it with `install_requires`. With this change, the package can be installed successfully in a clean virtual environment. For an example, see #4.