### PR TITLE
fix incorrect mp3 frame size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 from distutils.extension import Extension
 
 setup(name='streamp3',
-      version='0.1.6',
+      version='0.1.7',
       description="streaming mp3 decoder",
       long_description=open('README.md', 'r').read(),
       long_description_content_type='text/markdown',

--- a/streamp3/__init__.py
+++ b/streamp3/__init__.py
@@ -195,7 +195,8 @@ class MP3Decoder:
         self._num_channels = channels
 
         # calculate the size of the whole frame
-        frame_size = int(144 * bit_rate / sample_rate / (3 - channels))
+        frame_size = 1152 if version == 1 else 576
+        frame_size = bit_rate // 8 * frame_size // sample_rate
         if is_padded:
             frame_size += 1
 


### PR DESCRIPTION
The mp3 frame size was being calculated incorrectly for MPEG-2.5 streams and multi-channel streams, since the number of channels does not affect the size of the encoded frame (channels are factored into the bit rate). These changes correctly calculate the encoded frame size for multi-channel streams and add support for legacy MPEG-2.5 streams.