### PR TITLE
Update setup script for Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(name='streamp3',
       ext_modules=[Extension('lame.hip',
                              ['lame/hip.pyx'],
                              libraries=['mp3lame'])],
-      classifiers=("Programming Language :: Python :: 3",
+      classifiers=["Programming Language :: Python :: 3",
                    "License :: OSI Approved :: Apache Software License",
-                   "Operating System :: OS Independent"))
+                   "Operating System :: OS Independent"])


### PR DESCRIPTION
The [docs for the setup script](https://docs.python.org/3/distutils/setupscript.html#additional-meta-data) dictate that `classifiers` should be a list, and using a tuple produces a warning when trying to install with Python 3.7+.